### PR TITLE
Cleaned end game display. Added transition to next level. 

### DIFF
--- a/source/core/src/main/com/deco2800/game/components/endgame/EndGameActions.java
+++ b/source/core/src/main/com/deco2800/game/components/endgame/EndGameActions.java
@@ -19,14 +19,24 @@ public class EndGameActions extends Component {
 
   @Override
   public void create() {
+    entity.getEvents().addListener("nextLevel", this::onNextLevel);
     entity.getEvents().addListener("exit", this::onExit);
+  }
+
+  /**
+   * Swaps to the next level on the Main Game Screen.
+   */
+  private void onNextLevel() {
+    logger.info("Exiting end game screen...");
+    logger.info("Swapping to next level on main game screen...");
+    game.setScreen(GdxGame.ScreenType.MAIN_GAME);
   }
 
   /**
    * Swaps to the Main Menu screen.
    */
   private void onExit() {
-    logger.info("Exiting main game screen...");
+    logger.info("Exiting end game screen...");
     logger.info("Swapping to main menu screen...");
     game.setScreen(GdxGame.ScreenType.MAIN_MENU);
   }

--- a/source/core/src/main/com/deco2800/game/screens/EndGameScreen.java
+++ b/source/core/src/main/com/deco2800/game/screens/EndGameScreen.java
@@ -23,16 +23,18 @@ import org.slf4j.LoggerFactory;
  */
 public class EndGameScreen extends ScreenAdapter {
     private static final Logger logger = LoggerFactory.getLogger(EndGameScreen.class);
-    private static final String[] winScreenTextures = {"images/thumbsup.png"};
-    private static final String[] loseScreenTextures = {"images/thumbsdown.png"};
+    private static final String[] winScreenTextures = {"images/win_screen.png"};
+    private static final String[] loseScreenTextures = {"images/lose_screen.png"};
     private String[] activeScreenTextures;
+    private GdxGame.ScreenType result;
 
     private final GdxGame game;
     private final Renderer renderer;
 
     public EndGameScreen(GdxGame game, GdxGame.ScreenType result) {
         this.game = game;
-        switch (result) {
+        this.result = result;
+        switch (this.result) {
             case WIN_DEFAULT:
                 this.activeScreenTextures = winScreenTextures;
                 break;
@@ -89,6 +91,14 @@ public class EndGameScreen extends ScreenAdapter {
         ServiceLocator.clear();
     }
 
+    public GdxGame.ScreenType getResult() {
+        return this.result;
+    }
+
+    public String[] getActiveScreenTextures() {
+        return this.activeScreenTextures;
+    }
+
     private void loadAssets() {
         logger.debug("Loading assets");
         ResourceService resourceService = ServiceLocator.getResourceService();
@@ -110,7 +120,7 @@ public class EndGameScreen extends ScreenAdapter {
         logger.debug("Creating ui");
         Stage stage = ServiceLocator.getRenderService().getStage();
         Entity ui = new Entity();
-        ui.addComponent(new EndGameDisplay(this.activeScreenTextures))
+        ui.addComponent(new EndGameDisplay(this))
                 .addComponent(new InputDecorator(stage, 10))
                 .addComponent(new EndGameActions(game));
         ServiceLocator.getEntityService().register(ui);


### PR DESCRIPTION
Hao's screens are now implemented into the background in `EndGameDisplay`.

Cleaned up `EndGameDisplay` UI to show transitions to `MainGameScreen` and `MainMenuScreen`. New event added to `EndGameActions` to listen for when `nextLevelBtn` is pressed.

`EndGameDisplay` now calls on `EndGameScreen` to determine the result and `activeScreenTextures`. Requires reference to `EndGameScreen` in constructor instead. Added methods to `EndGameScreen` to get these variables. This was done to de-couple `EndGameDisplay` and variables already existing in `EndGameScreen`, whilst maintaining the single end game class paradigm. 